### PR TITLE
Adding cpp standard to compiler flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,13 @@ OFILES=$(patsubst %.cpp,%.o,$(CFILES))
 TARGET=MinecraftWeek
 
 FLAGS=-lGL -lpthread -lsfml-system -lsfml-window -lsfml-graphics -lGLEW
+CC_FLAGS=-std=c++17
 
 $(TARGET): $(OFILES)
 	g++ -o $(TARGET) $(OFILES) $(FLAGS)
 
 %.o: %.cpp
-	g++ -o $@ -c $<
+	g++ $(CC_FLAGS) -o $@ -c $<
 
 clean:
 	rm -rf $(TARGET) $(OFILES)

--- a/Source/Context.cpp
+++ b/Source/Context.cpp
@@ -21,8 +21,8 @@ Context::Context(const Config& config)
         window.create(winMode, "MineCraft Week", sf::Style::Close, settings);
     }
 
-    glewInit();
     glewExperimental = GL_TRUE;
+    glewInit();
     glViewport(0, 0, window.getSize().x, window.getSize().y);
 
     glCullFace(GL_BACK);


### PR DESCRIPTION
The program cannot be built with gcc without stating which version of C++ to use, because some libraries require at least C++14. So I set the standard to C++17, because it works and it is more future proof.

Additionally, I switched glewInit() and glewExperimental = GL_TRUE around, to give the usage of experimental an actual effect. Otherwise it wouldn't run on my system (Ubuntu 16.04 LTS).