### PR TITLE
Fixed a visual bug

### DIFF
--- a/Source/Player/Player.cpp
+++ b/Source/Player/Player.cpp
@@ -225,11 +225,13 @@ void Player::keyboardInput()
 
 void Player::mouseInput(const sf::RenderWindow& window)
 {
+    static sf::Vector2i lastMousePosition;
     static bool useMouse = true;
     static ToggleKey useMouseKey (sf::Keyboard::L);
 
     if (useMouseKey.isKeyPressed())
     {
+        sf::Mouse::setPosition( lastUsedMousePosition );
         useMouse = !useMouse;
     }
 
@@ -244,7 +246,7 @@ void Player::mouseInput(const sf::RenderWindow& window)
 	 };
 
     static auto const BOUND = 89.9999;
-    static auto lastMousePosition = sf::Mouse::getPosition(window);
+    lastMousePosition = sf::Mouse::getPosition(window);
     auto change = sf::Mouse::getPosition(window) - lastMousePosition;
 
     rotation.y += change.x * 0.05;


### PR DESCRIPTION
When disabling and re-enabling mouse usage, the view will shift to the new mouse position in older versions. The fix disables this behavior through moving the cursor to the old position, when the mouse is enabled.