### PR TITLE
Update TextureAtlas.cpp

### DIFF
--- a/Source/Texture/TextureAtlas.cpp
+++ b/Source/Texture/TextureAtlas.cpp
@@ -23,8 +23,8 @@ std::array<GLfloat, 8> TextureAtlas::getTexture(const sf::Vector2i& coords)
     GLfloat xMin = (coords.x * INDV_TEX_SIZE) + 0.5 * PIXEL_SIZE;
     GLfloat yMin = (coords.y * INDV_TEX_SIZE) + 0.5 * PIXEL_SIZE;
 
-    GLfloat xMax = (xMin + INDV_TEX_SIZE) - 0.5 * PIXEL_SIZE;
-    GLfloat yMax = (yMin + INDV_TEX_SIZE) - 0.5 * PIXEL_SIZE;
+    GLfloat xMax = (xMin + INDV_TEX_SIZE) - PIXEL_SIZE;
+    GLfloat yMax = (yMin + INDV_TEX_SIZE) - PIXEL_SIZE;
 
     return {
         xMax, yMax,


### PR DESCRIPTION
Fixed error in UV coord computation.

I think for xMax and yMax you need to subtract not 0.5 * PIXEL_SIZE, but 1.0 * PIXEL_SIZE.
(xMin + INDV_TEX_SIZE) will be half a pixel to the right of "the grid", and we want to be half a pixel to the left -> need to subtract whole pixel